### PR TITLE
Changed upsert_institution to return a session.get()

### DIFF
--- a/src/entities/repos/institutions_repo.py
+++ b/src/entities/repos/institutions_repo.py
@@ -83,9 +83,7 @@ async def upsert_institution(session: AsyncSession, fi: FinancialInstitutionDto)
             del fi_data["sbl_institution_type_ids"]
 
         db_fi = await session.merge(FinancialInstitutionDao(**fi_data))
-        await session.flush([db_fi])
-        await session.refresh(db_fi)
-        return db_fi
+        return await session.get(FinancialInstitutionDao, db_fi.lei)
 
 
 async def add_domains(


### PR DESCRIPTION
Closes #90 

Updated upsert_institution function to remove the flush and refresh and simplified to return a session.get(dao, lei) which will return the latest fully populated FIDao