### PR TITLE
93 synchronize linting setup between gh actions and local development

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -8,8 +8,12 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: psf/black@stable
+        with:
+          version: "~= 23.7.0"
   ruff:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: chartboost/ruff-action@v1
+        with:
+          version: "~= 0.0.278"

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -16,4 +16,4 @@ jobs:
       - uses: actions/checkout@v3
       - uses: chartboost/ruff-action@v1
         with:
-          version: "~= 0.0.278"
+          version: 0.0.278

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ alembic = "^1.12.0"
 pydantic-settings = "^2.0.3"
 
 [tool.poetry.group.dev.dependencies]
-ruff = "^0.0.278"
+ruff = "0.0.278"
 black = "^23.7.0"
 httpx = "^0.24.1"
 pytest = "^7.4.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ pydantic-settings = "^2.0.3"
 
 [tool.poetry.group.dev.dependencies]
 ruff = "0.0.278"
-black = "^23.7.0"
+black = "~23.7.0"
 httpx = "^0.24.1"
 pytest = "^7.4.0"
 pytest-asyncio = "^0.21.1"


### PR DESCRIPTION
Closes #93 

Updated the actions for black and ruff to have versions.  Black can take a compatible version definition using ~=.  However ruff-action has a strict regex that only allows a specific version to be defined, no concept of keeping the latest compatible major version.