### PR TITLE
feat: run as non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,6 @@ WORKDIR /usr/app/src
 
 EXPOSE 8888
 
+USER sbl
+
 CMD ["uvicorn", "regtech_user_fi_management.main:app", "--host", "0.0.0.0", "--port", "8888", "--log-config", "log-config.yml"]


### PR DESCRIPTION
Runs the user-fi container as unprivileged `sbl` user.

Validated the container is able to function properly with the change.