### PR TITLE
fix(api): fix spelling on some DTOs

### DIFF
--- a/src/regtech_user_fi_management/entities/models/dto.py
+++ b/src/regtech_user_fi_management/entities/models/dto.py
@@ -12,15 +12,15 @@ class VersionedData(BaseModel, Generic[T]):
     data: T
 
 
-class FinancialInsitutionDomainBase(BaseModel):
+class FinancialInstitutionDomainBase(BaseModel):
     domain: str
 
 
-class FinancialInsitutionDomainCreate(FinancialInsitutionDomainBase):
+class FinancialInstitutionDomainCreate(FinancialInstitutionDomainBase):
     pass
 
 
-class FinancialInsitutionDomainDto(FinancialInsitutionDomainBase):
+class FinancialInstitutionDomainDto(FinancialInstitutionDomainBase):
     lei: str
 
     class Config:
@@ -165,7 +165,7 @@ class FinancialInstitutionWithRelationsDto(FinancialInstitutionDto):
     sbl_institution_types: List[SblTypeAssociationDetailsDto] = []
     hq_address_state: AddressStateDto | None = None
     lei_status: LeiStatusDto | None = None
-    domains: List[FinancialInsitutionDomainDto] = []
+    domains: List[FinancialInstitutionDomainDto] = []
 
 
 class FinancialInstitutionAssociationDto(FinancialInstitutionWithRelationsDto):

--- a/src/regtech_user_fi_management/entities/repos/institutions_repo.py
+++ b/src/regtech_user_fi_management/entities/repos/institutions_repo.py
@@ -18,7 +18,7 @@ from regtech_user_fi_management.entities.models.dao import (
 
 from regtech_user_fi_management.entities.models.dto import (
     FinancialInstitutionDto,
-    FinancialInsitutionDomainCreate,
+    FinancialInstitutionDomainCreate,
     SblTypeAssociationDto,
 )
 
@@ -92,7 +92,7 @@ def update_sbl_types(
 
 
 def add_domains(
-    session: Session, lei: str, domains: List[FinancialInsitutionDomainCreate]
+    session: Session, lei: str, domains: List[FinancialInstitutionDomainCreate]
 ) -> Set[FinancialInstitutionDomainDao]:
     daos = set(
         map(

--- a/src/regtech_user_fi_management/routers/institutions.py
+++ b/src/regtech_user_fi_management/routers/institutions.py
@@ -12,8 +12,8 @@ import regtech_user_fi_management.entities.repos.institutions_repo as repo
 from regtech_user_fi_management.entities.models.dto import (
     FinancialInstitutionDto,
     FinancialInstitutionWithRelationsDto,
-    FinancialInsitutionDomainDto,
-    FinancialInsitutionDomainCreate,
+    FinancialInstitutionDomainDto,
+    FinancialInstitutionDomainCreate,
     FinancialInstitutionAssociationDto,
     InstitutionTypeDto,
     AddressStateDto,
@@ -163,12 +163,12 @@ def update_types(
             )
 
 
-@router.post("/{lei}/domains/", response_model=List[FinancialInsitutionDomainDto], dependencies=[Depends(check_domain)])
+@router.post("/{lei}/domains/", response_model=List[FinancialInstitutionDomainDto], dependencies=[Depends(check_domain)])
 @requires(["query-groups", "manage-users"])
 def add_domains(
     request: Request,
     lei: str,
-    domains: List[FinancialInsitutionDomainCreate],
+    domains: List[FinancialInstitutionDomainCreate],
 ):
     return repo.add_domains(request.state.db_session, lei, domains)
 

--- a/tests/entities/repos/test_institutions_repo.py
+++ b/tests/entities/repos/test_institutions_repo.py
@@ -4,7 +4,7 @@ from sqlalchemy.orm import Session
 
 from regtech_user_fi_management.entities.models.dto import (
     FinancialInstitutionDto,
-    FinancialInsitutionDomainCreate,
+    FinancialInstitutionDomainCreate,
     SblTypeAssociationDto,
 )
 from regtech_user_fi_management.entities.models.dao import (
@@ -331,7 +331,7 @@ class TestInstitutionsRepo:
         repo.add_domains(
             transaction_session,
             "TESTBANK123000000000",
-            [FinancialInsitutionDomainCreate(domain="bank.test")],
+            [FinancialInstitutionDomainCreate(domain="bank.test")],
         )
         transaction_session.expunge_all()
         fi = repo.get_institution(query_session, "TESTBANK123000000000")


### PR DESCRIPTION
closes #286

Some DTOs and models were misspelled using the word Insitution instead of Institution.

FinancialInstitutionDomainBase
FinancialInstitutionDomainCreate
FinancialInstitutionDomainDto

These show up in the generated swagger docs so should be fixed.