### PR TITLE
chore(actions): Enable linting on PRs

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -1,6 +1,8 @@
 name: Linters
 
-on: [push]
+on:
+  pull_request:
+  push:
 
 jobs:
   black:

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -3,6 +3,8 @@ name: Linters
 on:
   pull_request:
   push:
+    branches:
+      - main
 
 jobs:
   black:


### PR DESCRIPTION
closes #291

Should verify this actually did run the linter actions before merging.  I did notice it ran the actions on my branch, so I must have just missed those running before.